### PR TITLE
Generate Locale independent IDs

### DIFF
--- a/src/main/java/io/sharedstreets/data/SharedStreetsGeometry.java
+++ b/src/main/java/io/sharedstreets/data/SharedStreetsGeometry.java
@@ -15,7 +15,9 @@ import io.sharedstreets.tools.builder.util.UniqueId;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.Formatter;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 
@@ -106,15 +108,16 @@ public class SharedStreetsGeometry extends TilableData implements Serializable {
 
     // generate a stable ref
     public static UniqueId generateId(SharedStreetsGeometry ssg) {
-        String hashString = new String();
+        StringBuilder hashString = new StringBuilder();
+        Formatter formatter = new Formatter((Locale) null);
 
-        hashString = "Geometry";
+        hashString.append("Geometry");
 
         for(int i = 0; i < ((Polyline)ssg.geometry).getPointCount(); i++) {
-            hashString += String.format(" %.5f %.5f", ((Polyline)ssg.geometry).getPoint(i).getX(), ((Polyline)ssg.geometry).getPoint(i).getY());
+            hashString.append(formatter.format(" %.5f %.5f", ((Polyline)ssg.geometry).getPoint(i).getX(), ((Polyline)ssg.geometry).getPoint(i).getY()));
         }
 
-        return UniqueId.generateHash(hashString);
+        return UniqueId.generateHash(hashString.toString());
     }
 
 }

--- a/src/main/java/io/sharedstreets/data/SharedStreetsIntersection.java
+++ b/src/main/java/io/sharedstreets/data/SharedStreetsIntersection.java
@@ -11,6 +11,7 @@ import io.sharedstreets.tools.builder.util.geo.TileId;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 public class SharedStreetsIntersection extends TilableData implements Comparable, Serializable {
@@ -44,9 +45,7 @@ public class SharedStreetsIntersection extends TilableData implements Comparable
 
     public static UniqueId generateId(SharedStreetsIntersection ssi) {
 
-        String hashString = new String();
-
-        hashString = String.format("Intersection %.5f %.5f", ssi.point.getX(), ssi.point.getY());
+        String hashString = String.format((Locale) null, "Intersection %.5f %.5f", ssi.point.getX(), ssi.point.getY());
 
         // synthetic LPRs don't have node IDs...
         if(ssi.osmNodeId != null)

--- a/src/main/java/io/sharedstreets/data/SharedStreetsReference.java
+++ b/src/main/java/io/sharedstreets/data/SharedStreetsReference.java
@@ -3,8 +3,6 @@ package io.sharedstreets.data;
 
 import com.esri.core.geometry.Point;
 import com.esri.core.geometry.Polyline;
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Int32Value;
 import com.jsoniter.annotation.JsonIgnore;
 import io.sharedstreets.data.output.proto.SharedStreetsProto;
 import io.sharedstreets.tools.builder.osm.model.Way;
@@ -20,8 +18,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Formatter;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 public class SharedStreetsReference extends TilableData implements Serializable {
@@ -329,18 +329,20 @@ public class SharedStreetsReference extends TilableData implements Serializable 
 
     // generate a stable ref
     public static UniqueId generateId(SharedStreetsReference ssr) {
-        String hashString = new String();
+        StringBuilder hashString = new StringBuilder();
+        Formatter formatter = new Formatter((Locale) null);
 
-        hashString = "Reference " + ssr.formOfWay.value;
+        hashString.append("Reference ").append(ssr.formOfWay.value);
 
         for(SharedStreetsLocationReference lr : ssr.locationReferences) {
-            hashString += String.format(" %.5f %.5f", lr.point.getX(), lr.point.getY());
+            hashString.append(formatter.format(" %.5f %.5f", lr.point.getX(), lr.point.getY()));
             if(lr.outboundBearing != null) {
-                hashString += String.format(" %d", Math.round(lr.outboundBearing));
-                hashString += String.format(" %d", Math.round(lr.distanceToNextRef)); // hash of distance to next ref in meters -- stored in centimeters
+                hashString.append(formatter.format(" %d", Math.round(lr.outboundBearing)));
+                // Really stored in centimeters? Formerly distanceToNextRef was multiplied by 100, but not any longer...
+                hashString.append(formatter.format(" %d", Math.round(lr.distanceToNextRef))); // hash of distance to next ref in meters -- stored in centimeters
             }
         }
-        UniqueId id = UniqueId.generateHash(hashString);
+        UniqueId id = UniqueId.generateHash(hashString.toString());
 
         return id;
     }


### PR DESCRIPTION
Format hashInput without Locale. Use StringBuilder instead of String concatenation
 to reduce GC load.