### PR TITLE
Add option roadClasses

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@ Support for non-OSM data sources has been moved to the [sharedstreets-conflator]
 
 **Example use**
 
-`java -jar ./sharedstreets-builder-0.1-preview.jar --input data/[osm_input_file].pbf --output ./[tile_output_directory]
+`java -jar build/libs/sharedstreets-builder-0.3.1.jar --input data/[osm_input_file].pbf --output ./[tile_output_directory]
+`
+
+**Filtered Road Classes**
+
+Since v0.3 this tool generates tiles with hierarchically filtered road classes. Tiles with e.g. suffix `.2.pbf only contain road classes Motorway (0), Trunk (1) and Primary (2).
+Per default, tiles up to road class Unclassified (6) are generated. To create tiles up to road class Other (8), you may specify an optional `roadClasses` argument, providing the comma separated road classes tiles should be generated for:
+
+`java -jar build/libs/sharedstreets-builder-0.3.1.jar --input data/[osm_input_file].pbf --output ./[tile_output_directory] --roadClasses 0,1,2,4,6,8
 `
 
 **Notes**
@@ -20,4 +28,4 @@ The builder application is built on Apache Flink. If memory requirements exceed 
 
 - [*v0.1:*](https://github.com/sharedstreets/sharedstreets-builder/releases/tag/0.1-preview) OSM support
 - *v0.2:* Add OSM metadata support for support ways per [#9](https://github.com/sharedstreets/sharedstreets-builder/issues/9)
-- [*v0.3:*](https://github.com/sharedstreets/sharedstreets-builder/releases/tag/0.3) add heirarchical filterfing for roadClass per [sharedstreets-ref-system/#20](https://github.com/sharedstreets/sharedstreets-ref-system/issues/20#issuecomment-381010861)
+- [*v0.3:*](https://github.com/sharedstreets/sharedstreets-builder/releases/tag/0.3) add hierarchical filtering for roadClass per [sharedstreets-ref-system/#20](https://github.com/sharedstreets/sharedstreets-ref-system/issues/20#issuecomment-381010861)

--- a/src/main/java/io/sharedstreets/tools/builder/ProcessPBF.java
+++ b/src/main/java/io/sharedstreets/tools/builder/ProcessPBF.java
@@ -33,29 +33,29 @@ public class ProcessPBF {
         // create the Options
         Options options = new Options();
 
-        options.addOption( OptionBuilder.withLongOpt( "input" )
-                .withDescription( "path to input OSM PBF file" )
+        options.addOption( Option.builder().longOpt( "input" )
+                .desc( "path to input OSM PBF file" )
                 .hasArg()
-                .withArgName("INPUT-FILE")
-                .create() );
+                .argName("INPUT-FILE")
+                .build() );
 
-        options.addOption( OptionBuilder.withLongOpt( "output" )
-                .withDescription( "path to output directory (will be created)" )
+        options.addOption( Option.builder().longOpt( "output" )
+                .desc( "path to output directory (will be created)" )
                 .hasArg()
-                .withArgName("OUTPUT-DIR")
-                .create() );
+                .argName("OUTPUT-DIR")
+                .build() );
 
-        options.addOption( OptionBuilder.withLongOpt( "zlevel" )
-                .withDescription( "tile z-level (default 12)" )
+        options.addOption( Option.builder().longOpt( "zlevel" )
+                .desc( "tile z-level (default 12)" )
                 .hasArg()
-                .withArgName("Z-LEVEL")
-                .create() );
+                .argName("Z-LEVEL")
+                .build() );
 
-        options.addOption( OptionBuilder.withLongOpt( "roadClasses" )
-                .withDescription( "road classes (default '6,4,2,1,0')" )
+        options.addOption( Option.builder().longOpt( "roadClasses" )
+                .desc( "road classes (default '6,4,2,1,0')" )
                 .hasArg()
-                .withArgName("ROAD-CLASSES")
-                .create() );
+                .argName("ROAD-CLASSES")
+                .build() );
 
         String inputFile = "";
 

--- a/src/main/java/io/sharedstreets/tools/builder/ProcessPBF.java
+++ b/src/main/java/io/sharedstreets/tools/builder/ProcessPBF.java
@@ -1,8 +1,6 @@
 package io.sharedstreets.tools.builder;
 
-import io.sharedstreets.data.SharedStreetsGeometry;
 import io.sharedstreets.tools.builder.osm.model.Way;
-import io.sharedstreets.tools.builder.tiles.JSONTileOutputFormat;
 import io.sharedstreets.tools.builder.tiles.ProtoTileOutputFormat;
 import io.sharedstreets.tools.builder.tiles.TilableData;
 import io.sharedstreets.tools.builder.transforms.Intersections;
@@ -11,13 +9,8 @@ import io.sharedstreets.tools.builder.transforms.BaseSegments;
 import io.sharedstreets.tools.builder.transforms.SharedStreetData;
 import io.sharedstreets.tools.builder.util.geo.TileId;
 import org.apache.commons.cli.*;
-import org.apache.flink.api.common.functions.FilterFunction;
-import org.apache.flink.api.common.functions.MapFunction;
-import org.apache.flink.api.common.functions.ReduceFunction;
-import org.apache.flink.api.java.DataSet;
 import org.apache.flink.api.java.ExecutionEnvironment;
 
-import org.apache.flink.api.java.tuple.Tuple1;
 import org.apache.flink.api.java.tuple.Tuple2;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;

--- a/src/main/java/io/sharedstreets/tools/builder/ProcessPBF.java
+++ b/src/main/java/io/sharedstreets/tools/builder/ProcessPBF.java
@@ -36,6 +36,7 @@ public class ProcessPBF {
         options.addOption( Option.builder().longOpt( "input" )
                 .desc( "path to input OSM PBF file" )
                 .hasArg()
+                .required()
                 .argName("INPUT-FILE")
                 .build() );
 


### PR DESCRIPTION
To generate tiles containing e.g. road class Other, this PR adds an optional command line option roadClasses to supply the road classes for which a filtered tileset shall be created.

Additionally, this PR includes some minor cleanups (removing unused imports and deprecation and setting the input option required).